### PR TITLE
🐛 FIX: Name/label internal confusion

### DIFF
--- a/fixtures/directives.math.md
+++ b/fixtures/directives.math.md
@@ -1,11 +1,11 @@
 Math directive:
 .
 ```{math}
-:label: my_label
+:label: my-label
 w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 ```
 .
-<div class="math numbered" id="eq-my_label" number="1">
+<div class="math numbered" id="eq-my-label" number="1">
 w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 </div>
 .
@@ -17,6 +17,18 @@ w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 ```
 .
 <div class="math">
+w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
+</div>
+.
+
+Math directive:
+.
+```{math}
+:name: a-test
+w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
+```
+.
+<div class="math numbered" id="eq-a-test" number="1">
 w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 </div>
 .

--- a/src/directives/figure.ts
+++ b/src/directives/figure.ts
@@ -14,6 +14,7 @@ const figure = {
   figure: {
     token: 'figure',
     numbered: TargetKind.figure,
+    autoNumber: true,
     getArguments: (info) => {
       const args = { src: info.trim() };
       return { args, content: '' };

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -142,20 +142,16 @@ const numbering = (directives: Directives): RuleCore => (state) => {
   const { tokens } = state;
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index];
-    if (token.type === DirectiveTokens.open) {
+    if (token.type === DirectiveTokens.open || token.type === DirectiveTokens.fence) {
       const directive = getDirective(directives, token.attrGet('kind'));
-      if (directive?.numbered) {
-        const { name, label } = token.meta?.opts;
-        const target = newTarget(state, name || label, directive.numbered);
-        token.meta.target = target;
-      }
-    }
-    if (token.type === DirectiveTokens.fence) {
-      const directive = getDirective(directives, token.attrGet('kind'));
-      const { name, label } = token.meta?.opts;
-      // Only number things if the directive supports numbering AND a name or label is provided
-      if (directive?.numbered && (name || label)) {
-        const target = newTarget(state, name || label, directive.numbered);
+      const { name } = token.meta?.opts;
+      /* Only number things if:
+       *    * the directive supports numbering
+       *    * AND a name is provided
+       *    * OR autoNumber for the directive is on
+       */
+      if (directive?.numbered && (name || directive?.autoNumber)) {
+        const target = newTarget(state, name, directive.numbered);
         token.meta.target = target;
       }
     }

--- a/src/directives/math.ts
+++ b/src/directives/math.ts
@@ -6,7 +6,7 @@ export type Args = {
 };
 
 export type Opts = {
-  label: string;
+  name: string; // Note you can also use `label` here.
 };
 
 const math = {
@@ -16,9 +16,10 @@ const math = {
     skipParsing: true,
     getArguments: () => ({ args: {}, content: '' }),
     getOptions: (data) => {
-      const { label, ...rest } = data;
+      // See https://github.com/sphinx-doc/sphinx/issues/8476
+      const { name, label, ...rest } = data;
       unusedOptionsWarning('math', rest);
-      return { label };
+      return { name: name || label };
     },
     renderer: (args, opts, target) => {
       const { id, number } = target ?? {};

--- a/src/directives/types.ts
+++ b/src/directives/types.ts
@@ -14,7 +14,8 @@ export enum DirectiveTokens {
 export type Directive<Args extends {} = {}, Opts extends {} = {}> = {
   token: string;
   numbered?: TargetKind;
-  skipParsing?: true;
+  skipParsing?: true; // Uses the fence instead of markdown-it-container. Does not parse internals.
+  autoNumber?: true; // Always give the directive a numbered reference (only works if numbered)
   getArguments: (info: string) => { args: Args; content?: string };
   getOptions: (data: Record<string, string>) => Opts;
   renderer: (

--- a/src/roles/references.ts
+++ b/src/roles/references.ts
@@ -35,7 +35,8 @@ const renderReference = (
   } = target;
   let text = token.content || title || defaultReference;
   if (opts.numbered) {
-    text = text.replace('%s', String(number));
+    // See https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-numref
+    text = text.replace(/%s/g, String(number)).replace(/\{number\}/g, String(number));
   }
   if (opts.brackets) {
     text = `${token.content}(${number})`;

--- a/src/state.ts
+++ b/src/state.ts
@@ -68,7 +68,7 @@ function nextNumber(state: { env: any }, kind: TargetKind) {
 /** Create a new internal target.
  *
  * @param state MarkdownIt state that will be modified
- * @param id The reference id that will be used for the target
+ * @param name The reference name that will be used for the target. Note some directives use label.
  * @param kind The target kind: "ref", "equation", "code", "table" or "figure"
  */
 export function newTarget(state: { env: any }, name: string | undefined, kind: TargetKind) {


### PR DESCRIPTION
This falls back to and uses `name` internally for references. The `math` directive picks up on labels and uses that as the target name.

Also adds an `autoNumber` to the directives, which is on for figures.