### PR TITLE
🐛 BUG: Fix exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,5 @@ import { directives, Directive, Directives } from './directives';
 export type {
   Directive, Directives, Role, Roles,
 };
-export { default as MyST } from './myst';
+export { MyST } from './myst';
 export { plugins, roles, directives };

--- a/src/myst.ts
+++ b/src/myst.ts
@@ -19,7 +19,7 @@ export const defaultOptions: Options = {
   markdownit: { html: false },
 };
 
-export default function MyST(
+function MyST(
   opts: Options = defaultOptions,
 ) {
   const tokenizer = MarkdownIt('commonmark', opts.markdownit);
@@ -29,3 +29,5 @@ export default function MyST(
   tokenizer.use(plugins.roles(roles));
   return tokenizer;
 }
+
+export { MyST };


### PR DESCRIPTION
The default `{ MyST }` export wasn't working with rollup.